### PR TITLE
Automate load test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn-error.log
 dist
+.k6/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+MAKEFLAGS += --silent
+
+YARN_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find yarn. Please install it first.\033[0m\n"
+
+YARN := $(shell command -v yarn 2> /dev/null)
+
+all: clean build install-k6-es
+
+## check-prereq: Checks that required sofware is installed
+check-prereq:
+ifndef YARN
+	printf $(YARN_MISSING_HELP)
+	exit 1
+endif
+
+
+## help: Prints a list of available build targets.
+help:
+	echo "Usage: make <OPTIONS> ... <TARGETS>"
+	echo ""
+	echo "Available targets are:"
+	echo ''
+	sed -n 's/^##//p' ${PWD}/Makefile | column -t -s ':' | sed -e 's/^/ /'
+	echo
+	echo "Targets run by default are: `sed -n 's/^all: //p' ./Makefile | sed -e 's/ /, /g' | sed -e 's/\(.*\), /\1, and /'`"
+
+## clean: Removes any previously created build artifacts.
+clean:
+	rm -rf .k6 dist
+
+## install-k6-es: Installs k6 with the Elasticsearch connector
+install-k6-es:
+	@if [[ ! -d ".k6" ]]; then \
+		git clone git@github.com:elastic/xk6-output-elasticsearch.git .k6 ; \
+	else \
+		git -C .k6 pull --rebase ; \
+	fi;
+	cd .k6 && $(MAKE)
+
+## build: Builds load tests
+build: check-prereq
+	yarn install
+	yarn webpack
+
+.PHONY: check-prereq build install-k6-es clean help

--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ Space time benchmarking project with k6 tool
  - The entry points for the tests need to have "test" word in the name to distinguish them from auxiliary files.
 
 ## Running tests
+
+### Prerequisites
+
  - Make sure Kibana is running and eCommerce sample data is loaded
- - Install dependencies and transpile typescript code into JS and bundle the project: `yarn install && yarn webpack`
+
+### Directly with k6
+
+ - Install dependencies and transpile typescript code into JS and bundle the project: `make build`
  - Run your test:
     - using kibana.json in assets folder: `k6 run -e USE_KIBANA_JSON=1 dist/login_test.js`
     - by passing values directly: `k6 run -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme -e KIBANA_URL="http://localhost:5620" -e KIBANA_VERSION=8.3.0 dist/login_test.js`
+## Running tests directly with k6
+
+ - Ensure that Vault is properly setup
+ - Run your test:
+    - Running all load tests: `./k6.sh`
+    - Running only a specific test: `./k6.sh login_test`. Note that the test name must be passed without any file extension (i.e. pass `login_test` but not `login_test.ts`).
+
+The file `assets/kibana.json` defines the connection parameters to Kibana.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Space time benchmarking project with k6 tool
 ## Running tests directly with k6
 
  - Ensure that Vault is properly setup
+ - Ensure that Go 1.17 or better is installed and `GOPATH` is on your path (add `export PATH=$PATH:$(go env GOPATH)/bin` to `~/.profile` or `~/.zprofile`).
  - Run your test:
     - Running all load tests: `./k6.sh`
     - Running only a specific test: `./k6.sh login_test`. Note that the test name must be passed without any file extension (i.e. pass `login_test` but not `login_test.ts`).

--- a/k6.sh
+++ b/k6.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# fail this script immediately if any command fails with a non-zero exit code
+set -eu
+
+LOAD_TEST_ENV="${LOAD_TEST_ENV:-local}"
+
+run_single_test () {
+        load_test=$1
+        execution_id=$(uuidgen)
+
+        echo "Running $load_test in $LOAD_TEST_ENV (id: $execution_id)..."
+        # Phase 1 - warmup with a single user
+        .k6/k6 run -e USE_KIBANA_JSON=1 "$load_test" --quiet --vus 1 -o output-elasticsearch --tag user=$USER --tag run-id=${execution_id} --tag env=${LOAD_TEST_ENV} --tag phase=warmup
+        # Phase 2 - actual measurement
+        .k6/k6 run -e USE_KIBANA_JSON=1 "$load_test" -o output-elasticsearch --tag user=$USER --tag run-id=${execution_id} --tag env=${LOAD_TEST_ENV} --tag phase=measure
+}
+
+
+run_load_tests () {
+    export K6_ELASTICSEARCH_CLOUD_ID="$(vault read -field=cloud_id /secret/performance/employees/cloud/k6-metrics)"
+    export K6_ELASTICSEARCH_USER="$(vault read -field=es_username /secret/performance/employees/cloud/k6-metrics)"
+    export K6_ELASTICSEARCH_PASSWORD="$(vault read -field=es_password /secret/performance/employees/cloud/k6-metrics)"
+
+    # run all tests if no arguments are provided or run a specific test
+    if [[ $# -eq 1 ]]; then
+        run_single_test "dist/$1.js"
+    else
+        for load_test in dist/*.js; do
+            run_single_test $load_test
+        done
+    fi
+}
+
+make
+run_load_tests $@


### PR DESCRIPTION
With this commit we add a build script and an additional script to
simplify running load tests with k6. The load test results will be
written to a shared metrics store where they can be inspected. We also
include an automatic warmup phase that will be tagged separately.